### PR TITLE
make nested tabs based on scopes

### DIFF
--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -40,9 +40,8 @@ pub fn start() {
         let mut opened = input.chars().filter(|&c| c == '{').count();
         let mut closed = input.chars().filter(|&c| c == '}').count();
 
-        let mut nested = 1;
         while opened > closed {
-            print!("..{}", "  ".repeat(nested));
+            print!("..{}", "  ".repeat(opened));
             stdout().flush().unwrap();
 
             let mut input_nest = String::new();
@@ -52,7 +51,6 @@ pub fn start() {
             closed += input_nest.chars().filter(|&c| c == '}').count();
             opened += input_nest.chars().filter(|&c| c == '{').count();
 
-            nested += 1;
         }
 
         let Some(value) = runner::run_repl("<stdin>", input, &mut vm) else {

--- a/crates/core/src/repl.rs
+++ b/crates/core/src/repl.rs
@@ -15,20 +15,44 @@ pub fn start() {
     let mut vm = VirtualMachine::new(&mut gc);
 
     vm.init_globals();
-
     loop {
+        
         let mut input = String::new();
-
-        print!(">> ");
+            print!(">> ");
+        
 
         stdout().flush().unwrap();
 
         reader.read_line(&mut input).unwrap();
 
+        
         input = input.trim_end_matches('\n').to_string();
 
+        
         if input.is_empty() {
             continue;
+        } 
+        
+        if input == "\x03" {
+            break;
+        }
+
+        let mut opened = input.chars().filter(|&c| c == '{').count();
+        let mut closed = input.chars().filter(|&c| c == '}').count();
+
+        let mut nested = 1;
+        while opened > closed {
+            print!("..{}", "  ".repeat(nested));
+            stdout().flush().unwrap();
+
+            let mut input_nest = String::new();
+            reader.read_line(&mut input_nest).unwrap();
+            input_nest = input_nest.trim_end_matches('\n').to_string();
+            input += &input_nest;
+            closed += input_nest.chars().filter(|&c| c == '}').count();
+            opened += input_nest.chars().filter(|&c| c == '{').count();
+
+            nested += 1;
         }
 
         let Some(value) = runner::run_repl("<stdin>", input, &mut vm) else {


### PR DESCRIPTION
I've made a system where there's a nested representation of the code in REPL, so now, you can enter multi-line code if you made a new block and it will close when you type `}`.
