### PR TITLE
Use "to_float" instead of checking every combination

### DIFF
--- a/src/vm/builtins/Random.zig
+++ b/src/vm/builtins/Random.zig
@@ -8,77 +8,22 @@ pub fn addGlobals(vm: *VirtualMachine) std.mem.Allocator.Error!void {
 }
 
 fn random(vm: *VirtualMachine, arguments: []const VirtualMachine.Code.Value) VirtualMachine.Code.Value {
-    var min = arguments[0];
-    var max = arguments[1];
+    const Type = @import("Type.zig");
 
-    if ((min != .int and min != .float) or (max != .int and max != .float)) {
+    var min = Type.to_float(vm, &.{arguments[0]});
+    var max = Type.to_float(vm, &.{arguments[1]});
+
+    if (min == .none or max == .none) {
         return VirtualMachine.Code.Value{ .none = {} };
     }
 
-    switch (min) {
-        .int => switch (max) {
-            .int => {
-                if (min.int > max.int) {
-                    std.mem.swap(VirtualMachine.Code.Value, &min, &max);
-                } else if (min.int == max.int) {
-                    return VirtualMachine.Code.Value{ .float = @floatFromInt(min.int) };
-                }
-            },
-
-            .float => {
-                if (@as(f64, @floatFromInt(min.int)) > max.float) {
-                    std.mem.swap(VirtualMachine.Code.Value, &min, &max);
-                } else if (@as(f64, @floatFromInt(min.int)) == max.float) {
-                    return max;
-                }
-            },
-
-            else => unreachable,
-        },
-
-        .float => switch (max) {
-            .int => {
-                if (min.float > @as(f64, @floatFromInt(max.int))) {
-                    std.mem.swap(VirtualMachine.Code.Value, &min, &max);
-                } else if (min.float == @as(f64, @floatFromInt(max.int))) {
-                    return min;
-                }
-            },
-
-            .float => {
-                if (min.float > max.float) {
-                    std.mem.swap(VirtualMachine.Code.Value, &min, &max);
-                } else if (min.float > max.float) {
-                    return min;
-                }
-            },
-
-            else => unreachable,
-        },
-
-        else => unreachable,
+    if (min.float > max.float) {
+        std.mem.swap(VirtualMachine.Code.Value, &min, &max);
     }
 
     const RandGen = std.Random.DefaultPrng;
+
     var rnd = RandGen.init(@intCast(Time.time(vm, &.{}).int));
 
-    switch (min) {
-        .int => switch (max) {
-            .int => return VirtualMachine.Code.Value{ .float = std.math.lerp(@as(f64, @floatFromInt(min.int)), @as(f64, @floatFromInt(max.int)), rnd.random().float(f64)) },
-
-            .float => return VirtualMachine.Code.Value{ .float = std.math.lerp(@as(f64, @floatFromInt(min.int)), max.float, rnd.random().float(f64)) },
-
-            else => unreachable,
-        },
-
-        .float => switch (max) {
-            .int => return VirtualMachine.Code.Value{ .float = std.math.lerp(min.float, @as(f64, @floatFromInt(max.int)), rnd.random().float(f64)) },
-
-            .float => return VirtualMachine.Code.Value{ .float = std.math.lerp(min.float, max.float, rnd.random().float(f64)) },
-
-            else => unreachable,
-        },
-
-        else => unreachable,
-    }
+    return VirtualMachine.Code.Value{ .float = std.math.lerp(min.float, max.float, rnd.random().float(f64)) };
 }

--- a/src/vm/builtins/Type.zig
+++ b/src/vm/builtins/Type.zig
@@ -43,7 +43,7 @@ fn to_int(vm: *VirtualMachine, arguments: []const VirtualMachine.Code.Value) Vir
     }
 }
 
-fn to_float(vm: *VirtualMachine, arguments: []const VirtualMachine.Code.Value) VirtualMachine.Code.Value {
+pub fn to_float(vm: *VirtualMachine, arguments: []const VirtualMachine.Code.Value) VirtualMachine.Code.Value {
     _ = vm;
 
     const value = arguments[0];


### PR DESCRIPTION
Because we already can use "to_float" native function, it's not required to check every combination of min and max