### PR TITLE
New Approaches

### DIFF
--- a/docs/builtins/fs.md
+++ b/docs/builtins/fs.md
@@ -35,14 +35,6 @@ Closes a file by descriptor
 fs.close(fd)
 ```
 
-- close_all
-
-Closes all open files
-
-```
-fs.close_all()
-```
-
 - write
 
 Replaces the content of a file with the provided one

--- a/docs/builtins/http.md
+++ b/docs/builtins/http.md
@@ -15,9 +15,7 @@ http = import("http")
 Starts a server and calls the handler function on each request the server gets, the handler function is expected to get one parameter which is the request and returns a value which is the response
 
 ```
-fn handler(request) {
+http.listen("0.0.0.0", 8080, fn (request) {
     return "Hello, World!"
-}
-
-http.listen(address, port, handler)
+})
 ```

--- a/docs/data-types.md
+++ b/docs/data-types.md
@@ -1,5 +1,13 @@
 # Syphon's Data Types
 
+## None
+
+A value represents nothing
+
+```
+none
+```
+
 ## Number
 
 - Int
@@ -56,10 +64,16 @@ A map of key to value
 {"a": "b"}
 ```
 
-## None
+## Function
 
-A value represents nothing
+A callable value that is called by the virtual machine and must be defined the user
 
 ```
-none
+fn () {
+
+}
 ```
+
+## Native Function
+
+A callable value that is called by the host machine and must be defined by the virtual machine

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -1,31 +1,15 @@
 # Syphon's Syntax
 
-## Function Declaration
-
-- No Parameters
-```
-fn function_name() {
-
-}
-```
-
-- With Parameters
-```
-fn function_name(a, b) {
-
-}
-```
-
-## Function Calling
+## Calling
 
 - No Arguments
 ```
-function_name()
+callable()
 ```
 
 - With Arguments
 ```
-function_name(1, 2)
+callable(1, 2)
 ```
 
 ## Conditional

--- a/src/Driver.zig
+++ b/src/Driver.zig
@@ -192,12 +192,6 @@ fn runRunCommand(self: *Driver) u8 {
         return 1;
     };
 
-    vm.addGlobals() catch |err| {
-        std.debug.print("{s}\n", .{errorDescription(err)});
-
-        return 1;
-    };
-
     vm.setCode(gen.code) catch |err| {
         std.debug.print("{s}\n", .{errorDescription(err)});
 

--- a/src/vm/Code.zig
+++ b/src/vm/Code.zig
@@ -84,12 +84,11 @@ pub const Value = union(enum) {
         };
 
         pub const Function = struct {
-            name: []const u8,
             parameters: []const []const u8,
             code: Code,
 
-            pub fn init(gpa: std.mem.Allocator, name: []const u8, parameters: []const []const u8, code: Code) std.mem.Allocator.Error!Value {
-                const function: Function = .{ .name = name, .parameters = parameters, .code = code };
+            pub fn init(gpa: std.mem.Allocator, parameters: []const []const u8, code: Code) std.mem.Allocator.Error!Value {
+                const function: Function = .{ .parameters = parameters, .code = code };
 
                 var function_on_heap = try gpa.alloc(Function, 1);
                 function_on_heap[0] = function;
@@ -99,14 +98,13 @@ pub const Value = union(enum) {
         };
 
         pub const NativeFunction = struct {
-            name: []const u8,
             required_arguments_count: ?usize,
             call: Call,
 
             const Call = *const fn (*VirtualMachine, []const Value) Value;
 
-            pub fn init(name: []const u8, required_arguments_count: ?usize, call: Call) Value {
-                return Value{ .object = .{ .native_function = .{ .name = name, .required_arguments_count = required_arguments_count, .call = call } } };
+            pub fn init(required_arguments_count: ?usize, call: Call) Value {
+                return Value{ .object = .{ .native_function = .{ .required_arguments_count = required_arguments_count, .call = call } } };
             }
         };
     };

--- a/src/vm/VirtualMachine.zig
+++ b/src/vm/VirtualMachine.zig
@@ -141,7 +141,7 @@ pub fn addGlobals(self: *VirtualMachine) std.mem.Allocator.Error!void {
 }
 
 pub fn setCode(self: *VirtualMachine, code: Code) std.mem.Allocator.Error!void {
-    const value = try Code.Value.Object.Function.init(self.gpa, "entry", &.{}, code);
+    const value = try Code.Value.Object.Function.init(self.gpa, &.{}, code);
 
     try self.frames.append(.{
         .function = value.object.function,

--- a/src/vm/VirtualMachine.zig
+++ b/src/vm/VirtualMachine.zig
@@ -105,7 +105,7 @@ pub const MAX_FRAMES_COUNT = 128;
 pub const MAX_STACK_SIZE = MAX_FRAMES_COUNT * 255;
 
 pub fn init(gpa: std.mem.Allocator, argv: []const []const u8) Error!VirtualMachine {
-    return VirtualMachine{
+    var vm: VirtualMachine = .{
         .gpa = gpa,
         .frames = try std.ArrayList(Frame).initCapacity(gpa, MAX_FRAMES_COUNT),
         .stack = try std.ArrayList(Code.Value).initCapacity(gpa, MAX_STACK_SIZE),
@@ -114,6 +114,10 @@ pub fn init(gpa: std.mem.Allocator, argv: []const []const u8) Error!VirtualMachi
         .start_time = try std.time.Instant.now(),
         .argv = argv,
     };
+
+    try vm.addGlobals();
+
+    return vm;
 }
 
 pub fn addGlobals(self: *VirtualMachine) std.mem.Allocator.Error!void {

--- a/src/vm/VirtualMachine.zig
+++ b/src/vm/VirtualMachine.zig
@@ -17,8 +17,6 @@ exported_value: Code.Value,
 
 start_time: std.time.Instant,
 
-open_files: std.AutoHashMap(i32, std.fs.File),
-
 argv: []const []const u8,
 
 error_info: ?ErrorInfo = null,
@@ -114,7 +112,6 @@ pub fn init(gpa: std.mem.Allocator, argv: []const []const u8) Error!VirtualMachi
         .globals = std.StringHashMap(Code.Value).init(gpa),
         .exported_value = .{ .none = {} },
         .start_time = try std.time.Instant.now(),
-        .open_files = std.AutoHashMap(i32, std.fs.File).init(gpa),
         .argv = argv,
     };
 }

--- a/src/vm/VirtualMachine.zig
+++ b/src/vm/VirtualMachine.zig
@@ -137,17 +137,12 @@ pub fn addGlobals(self: *VirtualMachine) std.mem.Allocator.Error!void {
 }
 
 pub fn setCode(self: *VirtualMachine, code: Code) std.mem.Allocator.Error!void {
-    if (self.frames.items.len == 0) {
-        const value = try Code.Value.Object.Function.init(self.gpa, "entry", &.{}, code);
+    const value = try Code.Value.Object.Function.init(self.gpa, "entry", &.{}, code);
 
-        try self.frames.append(.{
-            .function = value.object.function,
-            .locals = try StringHashMapRecorder(usize).init(self.gpa),
-        });
-    } else {
-        self.frames.items[0].function.code = code;
-        self.frames.items[0].ip = 0;
-    }
+    try self.frames.append(.{
+        .function = value.object.function,
+        .locals = try StringHashMapRecorder(usize).init(self.gpa),
+    });
 }
 
 pub fn run(self: *VirtualMachine) Error!Code.Value {

--- a/src/vm/builtins/Array.zig
+++ b/src/vm/builtins/Array.zig
@@ -4,9 +4,9 @@ const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
 pub fn addGlobals(vm: *VirtualMachine) std.mem.Allocator.Error!void {
-    try vm.globals.put("array_push", Code.Value.Object.NativeFunction.init("array_push", 2, &array_push));
-    try vm.globals.put("array_pop", Code.Value.Object.NativeFunction.init("array_pop", 1, &array_pop));
-    try vm.globals.put("length", Code.Value.Object.NativeFunction.init("length", 1, &length));
+    try vm.globals.put("array_push", Code.Value.Object.NativeFunction.init(2, &array_push));
+    try vm.globals.put("array_pop", Code.Value.Object.NativeFunction.init(1, &array_pop));
+    try vm.globals.put("length", Code.Value.Object.NativeFunction.init(1, &length));
 }
 
 fn array_push(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {

--- a/src/vm/builtins/Console.zig
+++ b/src/vm/builtins/Console.zig
@@ -4,8 +4,8 @@ const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
 pub fn addGlobals(vm: *VirtualMachine) std.mem.Allocator.Error!void {
-    try vm.globals.put("print", Code.Value.Object.NativeFunction.init("print", null, &print));
-    try vm.globals.put("println", Code.Value.Object.NativeFunction.init("println", null, &println));
+    try vm.globals.put("print", Code.Value.Object.NativeFunction.init(null, &print));
+    try vm.globals.put("println", Code.Value.Object.NativeFunction.init(null, &println));
 }
 
 pub fn _print(comptime B: type, buffered_writer: *std.io.BufferedWriter(4096, B), arguments: []const Code.Value, debug: bool) !void {
@@ -74,9 +74,9 @@ pub fn _print(comptime B: type, buffered_writer: *std.io.BufferedWriter(4096, B)
                     _ = try buffered_writer.write("}");
                 },
 
-                .function => try buffered_writer.writer().print("<function '{s}'>", .{argument.object.function.name}),
+                .function => try buffered_writer.writer().print("<function>", .{}),
 
-                .native_function => try buffered_writer.writer().print("<native function '{s}'>", .{argument.object.native_function.name}),
+                .native_function => try buffered_writer.writer().print("<native function>", .{}),
             },
         }
 

--- a/src/vm/builtins/FileSystem.zig
+++ b/src/vm/builtins/FileSystem.zig
@@ -3,8 +3,8 @@ const std = @import("std");
 const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
-pub fn getExports(gpa: std.mem.Allocator) std.mem.Allocator.Error!Code.Value {
-    var exports = std.StringHashMap(Code.Value).init(gpa);
+pub fn getExports(vm: *VirtualMachine) std.mem.Allocator.Error!Code.Value {
+    var exports = std.StringHashMap(Code.Value).init(vm.gpa);
 
     try exports.put("open", Code.Value.Object.NativeFunction.init("open", 1, &open));
     try exports.put("delete", Code.Value.Object.NativeFunction.init("delete", 1, &delete));
@@ -18,7 +18,7 @@ pub fn getExports(gpa: std.mem.Allocator) std.mem.Allocator.Error!Code.Value {
     try exports.put("read_line", Code.Value.Object.NativeFunction.init("read_line", 1, &readLine));
     try exports.put("read_all", Code.Value.Object.NativeFunction.init("read_all", 1, &readAll));
 
-    return Code.Value.Object.Map.fromStringHashMap(gpa, exports);
+    return Code.Value.Object.Map.fromStringHashMap(vm.gpa, exports);
 }
 
 fn open(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {

--- a/src/vm/builtins/FileSystem.zig
+++ b/src/vm/builtins/FileSystem.zig
@@ -6,16 +6,16 @@ const VirtualMachine = @import("../VirtualMachine.zig");
 pub fn getExports(vm: *VirtualMachine) std.mem.Allocator.Error!Code.Value {
     var exports = std.StringHashMap(Code.Value).init(vm.gpa);
 
-    try exports.put("open", Code.Value.Object.NativeFunction.init("open", 1, &open));
-    try exports.put("delete", Code.Value.Object.NativeFunction.init("delete", 1, &delete));
-    try exports.put("close", Code.Value.Object.NativeFunction.init("close", 1, &close));
-    try exports.put("cwd", Code.Value.Object.NativeFunction.init("cwd", 0, &cwd));
-    try exports.put("chdir", Code.Value.Object.NativeFunction.init("chdir", 1, &chdir));
-    try exports.put("access", Code.Value.Object.NativeFunction.init("access", 1, &access));
-    try exports.put("write", Code.Value.Object.NativeFunction.init("write", 2, &write));
-    try exports.put("read", Code.Value.Object.NativeFunction.init("read", 1, &read));
-    try exports.put("read_line", Code.Value.Object.NativeFunction.init("read_line", 1, &readLine));
-    try exports.put("read_all", Code.Value.Object.NativeFunction.init("read_all", 1, &readAll));
+    try exports.put("open", Code.Value.Object.NativeFunction.init(1, &open));
+    try exports.put("delete", Code.Value.Object.NativeFunction.init(1, &delete));
+    try exports.put("close", Code.Value.Object.NativeFunction.init(1, &close));
+    try exports.put("cwd", Code.Value.Object.NativeFunction.init(0, &cwd));
+    try exports.put("chdir", Code.Value.Object.NativeFunction.init(1, &chdir));
+    try exports.put("access", Code.Value.Object.NativeFunction.init(1, &access));
+    try exports.put("write", Code.Value.Object.NativeFunction.init(2, &write));
+    try exports.put("read", Code.Value.Object.NativeFunction.init(1, &read));
+    try exports.put("read_line", Code.Value.Object.NativeFunction.init(1, &readLine));
+    try exports.put("read_all", Code.Value.Object.NativeFunction.init(1, &readAll));
 
     return Code.Value.Object.Map.fromStringHashMap(vm.gpa, exports);
 }

--- a/src/vm/builtins/Hash.zig
+++ b/src/vm/builtins/Hash.zig
@@ -4,7 +4,7 @@ const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
 pub fn addGlobals(vm: *VirtualMachine) std.mem.Allocator.Error!void {
-    try vm.globals.put("hash", Code.Value.Object.NativeFunction.init("hash", 1, &hash));
+    try vm.globals.put("hash", Code.Value.Object.NativeFunction.init(1, &hash));
 }
 
 fn hash(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {

--- a/src/vm/builtins/Http.zig
+++ b/src/vm/builtins/Http.zig
@@ -6,7 +6,7 @@ const VirtualMachine = @import("../VirtualMachine.zig");
 pub fn getExports(vm: *VirtualMachine) std.mem.Allocator.Error!Code.Value {
     var exports = std.StringHashMap(Code.Value).init(vm.gpa);
 
-    try exports.put("listen", Code.Value.Object.NativeFunction.init("listen", 3, &listen));
+    try exports.put("listen", Code.Value.Object.NativeFunction.init(3, &listen));
 
     return Code.Value.Object.Map.fromStringHashMap(vm.gpa, exports);
 }

--- a/src/vm/builtins/Http.zig
+++ b/src/vm/builtins/Http.zig
@@ -3,12 +3,12 @@ const std = @import("std");
 const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
-pub fn getExports(gpa: std.mem.Allocator) std.mem.Allocator.Error!Code.Value {
-    var exports = std.StringHashMap(Code.Value).init(gpa);
+pub fn getExports(vm: *VirtualMachine) std.mem.Allocator.Error!Code.Value {
+    var exports = std.StringHashMap(Code.Value).init(vm.gpa);
 
     try exports.put("listen", Code.Value.Object.NativeFunction.init("listen", 3, &listen));
 
-    return Code.Value.Object.Map.fromStringHashMap(gpa, exports);
+    return Code.Value.Object.Map.fromStringHashMap(vm.gpa, exports);
 }
 
 fn listen(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {

--- a/src/vm/builtins/Math.zig
+++ b/src/vm/builtins/Math.zig
@@ -3,13 +3,13 @@ const std = @import("std");
 const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
-pub fn getExports(gpa: std.mem.Allocator) std.mem.Allocator.Error!Code.Value {
-    var exports = std.StringHashMap(Code.Value).init(gpa);
+pub fn getExports(vm: *VirtualMachine) std.mem.Allocator.Error!Code.Value {
+    var exports = std.StringHashMap(Code.Value).init(vm.gpa);
 
     try exports.put("pi", .{ .float = std.math.pi });
     try exports.put("e", .{ .float = std.math.e });
     try exports.put("phi", .{ .float = std.math.phi });
     try exports.put("tau", .{ .float = std.math.tau });
 
-    return Code.Value.Object.Map.fromStringHashMap(gpa, exports);
+    return Code.Value.Object.Map.fromStringHashMap(vm.gpa, exports);
 }

--- a/src/vm/builtins/Module.zig
+++ b/src/vm/builtins/Module.zig
@@ -23,33 +23,34 @@ fn import(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {
 
     const file_path = arguments[0].object.string.content;
 
-    if (std.mem.eql(u8, file_path, "math")) {
-        return getMathModule(vm.gpa);
-    } else if (std.mem.eql(u8, file_path, "fs")) {
-        return getFileSystemModule(vm.gpa);
-    } else if (std.mem.eql(u8, file_path, "process")) {
-        return getProcessModule(vm);
-    } else if (std.mem.eql(u8, file_path, "http")) {
-        return getHttpModule(vm.gpa);
+    if (NativeModules.get(file_path)) |getNativeModule| {
+        return getNativeModule(vm);
     } else {
         return getExportedValue(vm, file_path);
     }
 }
 
-fn getMathModule(gpa: std.mem.Allocator) Code.Value {
+const NativeModules = std.StaticStringMap(*const fn (*VirtualMachine) Code.Value).initComptime(.{
+    .{ "math", &getMathModule },
+    .{ "fs", &getFileSystemModule },
+    .{ "process", &getProcessModule },
+    .{ "http", &getHttpModule },
+});
+
+fn getMathModule(vm: *VirtualMachine) Code.Value {
     const Math = @import("Math.zig");
 
-    const exports = Math.getExports(gpa) catch |err| switch (err) {
+    const exports = Math.getExports(vm) catch |err| switch (err) {
         else => return Code.Value{ .none = {} },
     };
 
     return exports;
 }
 
-fn getFileSystemModule(gpa: std.mem.Allocator) Code.Value {
+fn getFileSystemModule(vm: *VirtualMachine) Code.Value {
     const FileSystem = @import("FileSystem.zig");
 
-    const exports = FileSystem.getExports(gpa) catch |err| switch (err) {
+    const exports = FileSystem.getExports(vm) catch |err| switch (err) {
         else => return Code.Value{ .none = {} },
     };
 
@@ -66,10 +67,10 @@ fn getProcessModule(vm: *VirtualMachine) Code.Value {
     return exports;
 }
 
-fn getHttpModule(gpa: std.mem.Allocator) Code.Value {
+fn getHttpModule(vm: *VirtualMachine) Code.Value {
     const Http = @import("Http.zig");
 
-    const exports = Http.getExports(gpa) catch |err| switch (err) {
+    const exports = Http.getExports(vm) catch |err| switch (err) {
         else => return Code.Value{ .none = {} },
     };
 

--- a/src/vm/builtins/Module.zig
+++ b/src/vm/builtins/Module.zig
@@ -131,10 +131,6 @@ fn getExportedValue(vm: *VirtualMachine, file_path: []const u8) Code.Value {
         else => return Code.Value{ .none = {} },
     };
 
-    other_vm.addGlobals() catch |err| switch (err) {
-        else => return Code.Value{ .none = {} },
-    };
-
     other_vm.setCode(gen.code) catch |err| switch (err) {
         else => return Code.Value{ .none = {} },
     };

--- a/src/vm/builtins/Module.zig
+++ b/src/vm/builtins/Module.zig
@@ -6,8 +6,8 @@ const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
 pub fn addGlobals(vm: *VirtualMachine) std.mem.Allocator.Error!void {
-    try vm.globals.put("export", Code.Value.Object.NativeFunction.init("export", 1, &@"export"));
-    try vm.globals.put("import", Code.Value.Object.NativeFunction.init("import", 1, &import));
+    try vm.globals.put("export", Code.Value.Object.NativeFunction.init(1, &@"export"));
+    try vm.globals.put("import", Code.Value.Object.NativeFunction.init(1, &import));
 }
 
 fn @"export"(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {

--- a/src/vm/builtins/Process.zig
+++ b/src/vm/builtins/Process.zig
@@ -4,7 +4,7 @@ const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
 pub fn addGlobals(vm: *VirtualMachine) std.mem.Allocator.Error!void {
-    try vm.globals.put("exit", Code.Value.Object.NativeFunction.init("exit", 1, &exit));
+    try vm.globals.put("exit", Code.Value.Object.NativeFunction.init(1, &exit));
 }
 
 pub fn getExports(vm: *VirtualMachine) std.mem.Allocator.Error!Code.Value {

--- a/src/vm/builtins/Random.zig
+++ b/src/vm/builtins/Random.zig
@@ -5,7 +5,7 @@ const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
 pub fn addGlobals(vm: *VirtualMachine) std.mem.Allocator.Error!void {
-    try vm.globals.put("random", Code.Value.Object.NativeFunction.init("random", 2, &random));
+    try vm.globals.put("random", Code.Value.Object.NativeFunction.init(2, &random));
 }
 
 fn random(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {

--- a/src/vm/builtins/Time.zig
+++ b/src/vm/builtins/Time.zig
@@ -4,7 +4,7 @@ const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
 pub fn addGlobals(vm: *VirtualMachine) std.mem.Allocator.Error!void {
-    try vm.globals.put("time", Code.Value.Object.NativeFunction.init("time", 0, &time));
+    try vm.globals.put("time", Code.Value.Object.NativeFunction.init(0, &time));
 }
 
 pub fn time(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {

--- a/src/vm/builtins/Type.zig
+++ b/src/vm/builtins/Type.zig
@@ -4,10 +4,10 @@ const Code = @import("../Code.zig");
 const VirtualMachine = @import("../VirtualMachine.zig");
 
 pub fn addGlobals(vm: *VirtualMachine) std.mem.Allocator.Error!void {
-    try vm.globals.put("typeof", Code.Value.Object.NativeFunction.init("typeof", 1, &typeof));
-    try vm.globals.put("to_int", Code.Value.Object.NativeFunction.init("to_int", 1, &toInt));
-    try vm.globals.put("to_float", Code.Value.Object.NativeFunction.init("to_float", 1, &toFloat));
-    try vm.globals.put("to_string", Code.Value.Object.NativeFunction.init("to_string", 1, &toString));
+    try vm.globals.put("typeof", Code.Value.Object.NativeFunction.init(1, &typeof));
+    try vm.globals.put("to_int", Code.Value.Object.NativeFunction.init(1, &toInt));
+    try vm.globals.put("to_float", Code.Value.Object.NativeFunction.init(1, &toFloat));
+    try vm.globals.put("to_string", Code.Value.Object.NativeFunction.init(1, &toString));
 }
 
 fn typeof(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {

--- a/tests/benchmarks/arithmetic.sy
+++ b/tests/benchmarks/arithmetic.sy
@@ -1,6 +1,6 @@
 benchmarker = import("benchmarker.sy")
 
-fn benchmark() {
+benchmarker.run(fn () {
     result = 1
 
     i = 1
@@ -15,6 +15,4 @@ fn benchmark() {
 
         i += 1
     }
-}
-
-benchmarker.run(benchmark)
+})

--- a/tests/benchmarks/benchmarker.sy
+++ b/tests/benchmarks/benchmarker.sy
@@ -1,13 +1,11 @@
-fn run(benchmark) {
-    start = time()
-
-    benchmark()
-
-    end = time()
-
-    println("Took", (end - start) * 10 ** -6, "ms")
-}
-
 export({
-    "run": run,
+    "run": fn (benchmark) {
+        start = time()
+
+        benchmark()
+
+        end = time()
+
+        println("Took", (end - start) * 10 ** -6, "ms")
+    },
 })

--- a/tests/benchmarks/fibonacci.sy
+++ b/tests/benchmarks/fibonacci.sy
@@ -1,6 +1,6 @@
 benchmarker = import("benchmarker.sy")
 
-fn fib(n) {
+fib = fn (n) {
     if n < 2 {
         return n
     }
@@ -8,8 +8,6 @@ fn fib(n) {
     return fib(n - 1) + fib(n - 2)
 }
 
-fn benchmark() {
+benchmarker.run(fn () {
     fib(30)
-}
-
-benchmarker.run(benchmark)
+})

--- a/tests/benchmarks/loop.sy
+++ b/tests/benchmarks/loop.sy
@@ -1,11 +1,9 @@
 benchmarker = import("benchmarker.sy")
 
-fn benchmark() {
+benchmarker.run(fn () {
     i = 0
 
     while i < 10 ** 5 {
         i += 1
     }
-}
-
-benchmarker.run(benchmark)
+})

--- a/tests/integration/jump_search.sy
+++ b/tests/integration/jump_search.sy
@@ -1,4 +1,4 @@
-fn jump_search(arr, val, idx, jump_by) {
+jump_search = fn (arr, val, idx, jump_by) {
     if idx > length(arr) {
         return jump_search(arr, val, idx - jump_by, 1)
     } else if arr[idx] > val {

--- a/tests/integration/selection_sort.sy
+++ b/tests/integration/selection_sort.sy
@@ -1,4 +1,4 @@
-fn selection_sort(arr) {
+selection_sort = fn (arr) {
     i = 0
 
     while i < length(arr) {


### PR DESCRIPTION
- use StaticStringMap instead of manually checking the native module the user wants
- use the fd provided directly as file.handle and remove the useless allocation of open_files field
- remove the useless checking in the setCode, it is guranteed to be called only once when initializing the virtual machine
- always call addGlobals
- replace named functions with anonymous functions