### PR TITLE
feat: add functions `range` and `reverse`

### DIFF
--- a/docs/builtins/global.md
+++ b/docs/builtins/global.md
@@ -173,6 +173,37 @@ foreach(map, fn (k, v) {
 })
 ```
 
+- range
+
+Gives back a ranged Array of integers, you can specify the start point, the end point, and the step incrementor
+
+```
+# if given a single argument it will use the start point of 0 and the step incrementor of 1
+range(4) # [0, 1, 2, 3]
+
+# if given two arguments it will use the first as the starting point and the second ans the ending point
+range(1, 6) # [1, 2, 3, 4, 5]
+
+# if given three arguments it will act the pass two arugments but it will use the thrid arugment as the step incrementor
+range(0, 12, 2) # [0, 2, 4, 6, 8, 10]
+
+```
+
+- reverse
+
+Gives a reversed version of the passed in iterable (array, string)
+
+```
+
+arr = ["foo", "bar", "foobar", "human"]
+
+str = "hello, world!"
+
+reverse(arr) # ["human", "foobar", "bar", "foo"]
+
+reverse(str) # !dlrow ,olleh
+```
+
 - filter
 
 Filter an iterable (array, string, map) based on its member values using a callback, the callback **must** return a boolean value

--- a/src/vm/builtins/Array.zig
+++ b/src/vm/builtins/Array.zig
@@ -7,7 +7,6 @@ const Atom = @import("../Atom.zig");
 pub fn addGlobals(vm: *VirtualMachine) std.mem.Allocator.Error!void {
     try vm.globals.put(try Atom.new("array_push"), Code.Value.Object.NativeFunction.init(2, &arrayPush));
     try vm.globals.put(try Atom.new("array_pop"), Code.Value.Object.NativeFunction.init(1, &arrayPop));
-    try vm.globals.put(try Atom.new("array_reverse"), Code.Value.Object.NativeFunction.init(1, &arrayReverse));
 }
 
 fn arrayPush(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {
@@ -38,22 +37,4 @@ fn arrayPop(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {
     const array = arguments[0].object.array;
 
     return array.values.popOrNull() orelse Code.Value{ .none = {} };
-}
-
-fn arrayReverse(vm: *VirtualMachine, arguments: []const Code.Value) Code.Value {
-    if (!(arguments[0] == .object and arguments[0].object == .array)) {
-        return Code.Value{ .none = {} };
-    }
-
-    const array = arguments[0].object.array;
-
-    var new_array = std.ArrayList(Code.Value).initCapacity(vm.allocator, array.values.items.len) catch |err| switch (err) {
-        else => return Code.Value{ .none = {} },
-    };
-
-    for (0..array.values.items.len) |i| {
-        new_array.appendAssumeCapacity(array.values.items[array.values.items.len - 1 - i]);
-    }
-
-    return Code.Value.Object.Array.init(vm.allocator, new_array) catch Code.Value{ .none = {} };
 }

--- a/tests/integration/range.sy
+++ b/tests/integration/range.sy
@@ -1,0 +1,28 @@
+tester = import("tester.sy")
+
+test_1 = fn () {
+    # generate a range array and validate it
+    expected_arr = [0, 1, 2, 3, 4, 5]
+    range_arr = range(6)
+    return range_arr == expected_arr
+}
+
+test_2 = fn () {
+    # generate a range array with a specified starting point and validate it
+    expected_arr = [1, 2, 3, 4, 5]
+    range_arr = range(1, 6)
+    return range_arr == expected_arr
+}
+
+test_3 = fn () {
+    # generate a range array with a specified starting point and step incrementor validate it
+    expected_arr = [0, 2, 4, 6, 8, 10]
+    range_arr = range(0, 12, 2)
+    return range_arr == expected_arr
+}
+
+tester.test([
+    test_1,
+    test_2,
+    test_3,
+])

--- a/tests/integration/reverse.sy
+++ b/tests/integration/reverse.sy
@@ -1,0 +1,20 @@
+tester = import("tester.sy")
+
+test_1 = fn () {
+    # reverse an array of mixed types
+    expected_arr = [[3], 2, 1, "0"]
+    reversed_arr = reverse(["0", 1, 2, [3]])
+    return reversed_arr == expected_arr
+}
+
+test_2 = fn () {
+    # reverse a string
+    expected_str = "321!dlrow ,olleh"
+    reversed_str = reverse("hello, world!123")
+    return reversed_str == expected_str
+}
+
+tester.test([
+    test_1,
+    test_2,
+])


### PR DESCRIPTION
this PR removes the function `array_reverse` which is implemented for arrays only, unlike `reverse`, it can work for strings and arrays

this PR also provides documentations and tests for both functions
